### PR TITLE
Add backend API and React TipTap frontend for IntelliPaper MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+dist

--- a/backend/data/documents.json
+++ b/backend/data/documents.json
@@ -1,0 +1,6 @@
+{
+  "1": {
+    "id": 1,
+    "content": "This is a sample document for the IntelliPaper demo. Highlight text and ask the AI for help."
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "intellipaper-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "openai": "^4.37.0"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,51 @@
+import express from 'express';
+import cors from 'cors';
+import { readFile } from 'fs/promises';
+import dotenv from 'dotenv';
+import OpenAI from 'openai';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+let documents = {};
+try {
+  const data = await readFile(new URL('./data/documents.json', import.meta.url), 'utf-8');
+  documents = JSON.parse(data);
+} catch (err) {
+  console.error('Could not load documents:', err);
+}
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.post('/api/analyze', async (req, res) => {
+  const { documentId, highlightedText, query } = req.body;
+  if (!highlightedText || !query) {
+    return res.status(400).json({ error: 'highlightedText and query are required' });
+  }
+  try {
+    const prompt = `You are assisting with document editing. The user highlighted: "${highlightedText}". They ask: "${query}". Respond with JSON {"response": <answer>, "suggestedEdit": <new text or null>}.`;
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    });
+    let ai = completion.choices[0].message.content;
+    let parsed;
+    try {
+      parsed = JSON.parse(ai);
+    } catch (e) {
+      parsed = { response: ai, suggestedEdit: null };
+    }
+    res.json(parsed);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'AI analysis failed' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IntelliPaper</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "intellipaper-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@tiptap/react": "^2.3.1",
+    "@tiptap/starter-kit": "^2.3.1",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import axios from 'axios';
+
+const initialContent = 'This is a sample document for the IntelliPaper demo. Highlight text and ask the AI for help.';
+
+export default function App() {
+  const [query, setQuery] = useState('');
+  const [response, setResponse] = useState(null);
+  const [selection, setSelection] = useState({ from: 0, to: 0, text: '' });
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: initialContent,
+    onSelectionUpdate: ({ editor }) => {
+      const { from, to } = editor.state.selection;
+      const text = editor.state.doc.textBetween(from, to, ' ');
+      setSelection({ from, to, text });
+    }
+  });
+
+  const submitQuery = async () => {
+    if (!selection.text || !query.trim()) return;
+    try {
+      const res = await axios.post('http://localhost:3001/api/analyze', {
+        documentId: 1,
+        highlightedText: selection.text,
+        query
+      });
+      setResponse(res.data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const applyEdit = () => {
+    if (response?.suggestedEdit) {
+      editor.commands.insertContentAt(
+        { from: selection.from, to: selection.to },
+        response.suggestedEdit
+      );
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div style={{ flex: 1, padding: '1rem' }}>
+        <EditorContent editor={editor} />
+        <textarea
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Ask about the highlight..."
+          style={{ width: '100%', marginTop: '1rem' }}
+        />
+        <button onClick={submitQuery} style={{ marginTop: '0.5rem' }}>Send</button>
+      </div>
+      <div style={{ width: '30%', padding: '1rem', borderLeft: '1px solid #ccc' }}>
+        {response ? (
+          <div>
+            <p>{response.response}</p>
+            {response.suggestedEdit && (
+              <button onClick={applyEdit}>Apply Suggestion</button>
+            )}
+          </div>
+        ) : (
+          <p>Select text and ask a question to get started.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "intellipaper",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "npm --prefix frontend run dev"
+  }
+}


### PR DESCRIPTION
## Summary
- Implement Express backend with /api/analyze endpoint hooked to OpenAI
- Add React + TipTap editor front-end with highlight query and inline edit suggestions
- Provide sample document and environment config for easy local testing

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ba1d61527c8326994f2811f3fce94b