### PR TITLE
feat: highlight-aware editor and AI sidebar

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import cors from 'cors';
-import { readFile } from 'fs/promises';
 import dotenv from 'dotenv';
 import OpenAI from 'openai';
 
@@ -10,23 +9,15 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-let documents = {};
-try {
-  const data = await readFile(new URL('./data/documents.json', import.meta.url), 'utf-8');
-  documents = JSON.parse(data);
-} catch (err) {
-  console.error('Could not load documents:', err);
-}
-
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 app.post('/api/analyze', async (req, res) => {
-  const { documentId, highlightedText, query } = req.body;
-  if (!highlightedText || !query) {
-    return res.status(400).json({ error: 'highlightedText and query are required' });
+  const { documentText, highlightedText, userQuery } = req.body;
+  if (!highlightedText || !userQuery) {
+    return res.status(400).json({ error: 'highlightedText and userQuery are required' });
   }
   try {
-    const prompt = `You are assisting with document editing. The user highlighted: "${highlightedText}". They ask: "${query}". Respond with JSON {"response": <answer>, "suggestedEdit": <new text or null>}.`;
+    const prompt = `You are assisting with document editing.\nDocument: "${documentText}"\nHighlighted: "${highlightedText}"\nUser asks: "${userQuery}"\nRespond with JSON {"response": <answer>, "suggestedEdit": <new text or null>}.`;
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [{ role: 'user', content: prompt }]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import axios from 'axios';
+import Sidebar from './Sidebar';
 
 const initialContent = 'This is a sample document for the IntelliPaper demo. Highlight text and ask the AI for help.';
 
 export default function App() {
-  const [query, setQuery] = useState('');
+  const [userQuery, setUserQuery] = useState('');
   const [response, setResponse] = useState(null);
   const [selection, setSelection] = useState({ from: 0, to: 0, text: '' });
 
@@ -21,12 +22,12 @@ export default function App() {
   });
 
   const submitQuery = async () => {
-    if (!selection.text || !query.trim()) return;
+    if (!selection.text || !userQuery.trim()) return;
     try {
       const res = await axios.post('http://localhost:3001/api/analyze', {
-        documentId: 1,
+        documentText: editor.getText(),
         highlightedText: selection.text,
-        query
+        userQuery
       });
       setResponse(res.data);
     } catch (e) {
@@ -48,25 +49,14 @@ export default function App() {
       <div style={{ flex: 1, padding: '1rem' }}>
         <EditorContent editor={editor} />
         <textarea
-          value={query}
-          onChange={e => setQuery(e.target.value)}
+          value={userQuery}
+          onChange={e => setUserQuery(e.target.value)}
           placeholder="Ask about the highlight..."
           style={{ width: '100%', marginTop: '1rem' }}
         />
-        <button onClick={submitQuery} style={{ marginTop: '0.5rem' }}>Send</button>
+        <button onClick={submitQuery} style={{ marginTop: '0.5rem' }}>Ask AI</button>
       </div>
-      <div style={{ width: '30%', padding: '1rem', borderLeft: '1px solid #ccc' }}>
-        {response ? (
-          <div>
-            <p>{response.response}</p>
-            {response.suggestedEdit && (
-              <button onClick={applyEdit}>Apply Suggestion</button>
-            )}
-          </div>
-        ) : (
-          <p>Select text and ask a question to get started.</p>
-        )}
-      </div>
+      <Sidebar response={response} onApply={applyEdit} />
     </div>
   );
 }

--- a/frontend/src/Sidebar.jsx
+++ b/frontend/src/Sidebar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Sidebar({ response, onApply }) {
+  return (
+    <div style={{ width: '30%', padding: '1rem', borderLeft: '1px solid #ccc' }}>
+      {response ? (
+        <div>
+          <p>{response.response}</p>
+          {response.suggestedEdit && (
+            <button onClick={onApply}>Apply Suggestion</button>
+          )}
+        </div>
+      ) : (
+        <p>Select text and ask a question to get started.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- switch backend `/api/analyze` to accept `{documentText, highlightedText, userQuery}` and craft richer prompt
- replace textarea front-end with TipTap editor and send full document text to backend
- add sidebar component showing AI response and optional apply-suggestion button

## Testing
- ⚠️ `npm test` (no test script)
- ⚠️ `cd backend && npm test` (no test script)
- ⚠️ `cd frontend && npm test` (no test script)
- ⚠️ `node backend/server.js` (missing express dependency)


------
https://chatgpt.com/codex/tasks/task_e_68ba243c5e2083269d60b302e86c1ced