### PR TITLE
feat: persist documents with schema-backed API

### DIFF
--- a/backend/data/documentSchema.json
+++ b/backend/data/documentSchema.json
@@ -1,0 +1,15 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "attrs": { "textAlign": "left" },
+      "content": [
+        {
+          "type": "text",
+          "text": "This is a sample document for the IntelliPaper demo. Highlight text and ask the AI for help."
+        }
+      ]
+    }
+  ]
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,9 @@ import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import OpenAI from 'openai';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 dotenv.config();
 
@@ -9,7 +12,31 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_FILE = path.join(__dirname, 'data', 'documentSchema.json');
+
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.get('/api/document', async (req, res) => {
+  try {
+    const data = await fs.readFile(DATA_FILE, 'utf8');
+    res.json(JSON.parse(data));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load document' });
+  }
+});
+
+app.post('/api/document', async (req, res) => {
+  try {
+    await fs.writeFile(DATA_FILE, JSON.stringify(req.body, null, 2));
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save document' });
+  }
+});
 
 app.post('/api/ai', async (req, res) => {
   const { documentText, command } = req.body;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -64,16 +64,34 @@ export default function App() {
   const [showSlash, setShowSlash] = useState(false);
   const [slashIndex, setSlashIndex] = useState(0);
 
+  const [initialContent, setInitialContent] = useState(null);
+
   const slashCommands = [
     { label: 'Summarize', value: 'summarize' },
     { label: 'Expand', value: 'expand' },
     { label: 'Rewrite', value: 'rewrite' },
   ];
 
-  const editor = useEditor({
-    extensions: [StarterKit, Ghost],
-    content: '',
-  });
+  useEffect(() => {
+    const fetchDoc = async () => {
+      try {
+        const res = await axios.get('http://localhost:3001/api/document');
+        setInitialContent(res.data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchDoc();
+  }, []);
+
+  const editor = useEditor(
+    initialContent
+      ? {
+          extensions: [StarterKit, Ghost],
+          content: initialContent,
+        }
+      : null
+  );
 
   const PAGE_HEIGHT = 1056; // ~11in @96dpi
   const PAGE_GAP = 32;
@@ -124,6 +142,9 @@ export default function App() {
     const updateHandler = ({ editor }) => {
       const text = editor.getText();
       clearGhost();
+      axios
+        .post('http://localhost:3001/api/document', editor.getJSON())
+        .catch(err => console.error(err));
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(async () => {
         if (!text.trim()) return;


### PR DESCRIPTION
## Summary
- store rich document schema in `backend/data/documentSchema.json`
- add Express endpoints for loading and saving the document schema
- initialize TipTap editor with data fetched from backend and persist edits

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d7fbfc48326af343b44b66b8594