### PR TITLE
Add streaming chat panel and command endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -80,6 +80,42 @@ app.post('/api/ai', async (req, res) => {
   }
 });
 
+// Stream AI-generated edits for a given instruction and selection.
+// The client sends the user's instruction along with the currently
+// selected text. The endpoint streams back the revised text which can
+// be applied on the client to update the document model.
+app.post('/api/commands', async (req, res) => {
+  const { instruction, selectedText = '' } = req.body || {};
+  if (!instruction) {
+    return res.status(400).json({ error: 'instruction is required' });
+  }
+
+  const prompt = `You are a helpful document editor. The user has selected the following text:\n\n${selectedText}\n\nInstruction: ${instruction}\n\nReturn the updated selection text:`;
+
+  try {
+    const stream = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      stream: true,
+    });
+
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('Transfer-Encoding', 'chunked');
+
+    for await (const part of stream) {
+      const token = part.choices[0]?.delta?.content || '';
+      if (token) {
+        res.write(token);
+      }
+    }
+
+    res.end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Command processing failed' });
+  }
+});
+
 function buildPrompt(text, command) {
   switch (command) {
     case 'summarize':

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -99,6 +99,9 @@ export default function App() {
   const [pageCount, setPageCount] = useState(1);
   const editorContainerRef = useRef(null);
 
+  const [messages, setMessages] = useState([]);
+  const [chatInput, setChatInput] = useState('');
+
   // Recalculate page count whenever the editor size or page height changes
   useEffect(() => {
     if (!editorContainerRef.current) return;
@@ -261,6 +264,40 @@ export default function App() {
     };
   }, [editor, slashIndex, showSlash]);
 
+  const sendCommand = async () => {
+    if (!editor || !chatInput.trim()) return;
+    const { from, to } = editor.state.selection;
+    const selectedText = editor.state.doc.textBetween(from, to, '\n');
+    const userMessage = { role: 'user', content: chatInput };
+    setMessages(prev => [...prev, userMessage, { role: 'assistant', content: '' }]);
+    setChatInput('');
+    try {
+      const res = await fetch('http://localhost:3001/api/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instruction: userMessage.content, selectedText }),
+      });
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let aiText = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        aiText += decoder.decode(value);
+        setMessages(prev => {
+          const updated = [...prev];
+          updated[updated.length - 1] = { role: 'assistant', content: aiText };
+          return updated;
+        });
+      }
+
+      editor.chain().focus().insertContentAt({ from, to }, aiText).run();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <div className="flex h-screen flex-col bg-gray-50">
       <header className="flex items-center justify-between border-b bg-white px-6 py-3">
@@ -318,11 +355,33 @@ export default function App() {
             </div>
           </div>
         </div>
-        <aside className="hidden w-64 flex-shrink-0 border-l bg-white p-6 md:block">
-          <h2 className="mb-4 text-sm font-semibold text-gray-600">AI Insights</h2>
-          <p className="text-sm text-gray-500">
-            Deeper AI insights will appear here.
-          </p>
+        <aside className="hidden w-80 flex-shrink-0 border-l bg-white md:flex md:flex-col">
+          <div className="flex-1 overflow-y-auto p-4">
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={`mb-2 text-sm ${
+                  m.role === 'user' ? 'text-gray-800' : 'text-blue-600'
+                }`}
+              >
+                {m.content}
+              </div>
+            ))}
+          </div>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              sendCommand();
+            }}
+            className="border-t p-2"
+          >
+            <input
+              value={chatInput}
+              onChange={e => setChatInput(e.target.value)}
+              placeholder="Send a command..."
+              className="w-full rounded border px-2 py-1 text-sm"
+            />
+          </form>
         </aside>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce `/api/commands` endpoint that streams AI-generated edits based on selection
- add right-side chat panel for streaming conversations and applying AI edits

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4fc4aaf483268e02bc235b0c758a