### PR TITLE
Import global stylesheet in entry point

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,3 +1,4 @@
+import './index.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';


### PR DESCRIPTION
## Summary
- import the global `index.css` in the main React entry point so Tailwind classes load

## Testing
- `npm --prefix frontend install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2ftypography)*
- `npm --prefix frontend exec vite build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix frontend test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba6f14df688326aa97ef0236fd274b