### PR TITLE
Add Jest tests for backend API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ Documents are alive → they suggest, critique, and adapt as you write.
 The system uses multiple AI agents (grammar, style, logic, layout, etc.) to collaborate with the user.
 
 The goal: writing becomes a conversation with the document itself, not just text on a static page.
+
+## Backend Tests
+
+The backend includes a Jest test suite covering document storage, plugin actions, and AI endpoints.
+
+Run the tests with:
+
+```bash
+cd backend
+npm test
+```
+
+The tests mock OpenAI calls, so no API key is required.

--- a/backend/__tests__/api.test.js
+++ b/backend/__tests__/api.test.js
@@ -1,0 +1,76 @@
+import request from 'supertest';
+import { promises as fs } from 'fs';
+
+const mockCreate = jest.fn(params => {
+  if (params.stream) {
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'Hello' } }] };
+        yield { choices: [{ delta: { content: ' World' } }] };
+      },
+    };
+  }
+  return {
+    choices: [{ message: { content: 'Mock suggestion' } }],
+  };
+});
+
+await jest.unstable_mockModule('openai', () => ({
+  default: function () {
+    return { chat: { completions: { create: mockCreate } } };
+  },
+}));
+
+const { app, server } = await import('../server.js');
+
+afterAll(() => {
+  server.close();
+});
+
+describe('/api/document', () => {
+  it('returns document content', async () => {
+    const data = { hello: 'world' };
+    const readSpy = jest.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify(data));
+    const res = await request(app).get('/api/document');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(data);
+    readSpy.mockRestore();
+  });
+
+  it('saves document content', async () => {
+    const writeSpy = jest.spyOn(fs, 'writeFile').mockResolvedValue();
+    const payload = { foo: 'bar' };
+    const res = await request(app).post('/api/document').send(payload);
+    expect(res.status).toBe(200);
+    expect(writeSpy).toHaveBeenCalledWith(expect.any(String), JSON.stringify(payload, null, 2));
+    writeSpy.mockRestore();
+  });
+});
+
+describe('/api/plugins/:plugin/:action', () => {
+  it('invokes plugin action', async () => {
+    const res = await request(app)
+      .post('/api/plugins/uppercase/shout')
+      .send({ text: 'hello' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ result: 'HELLO' });
+  });
+});
+
+describe('OpenAI dependent endpoints', () => {
+  it('/api/ai returns suggestion', async () => {
+    const res = await request(app)
+      .post('/api/ai')
+      .send({ documentText: 'text', command: 'summarize' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ suggestion: 'Mock suggestion' });
+  });
+
+  it('/api/commands streams response', async () => {
+    const res = await request(app)
+      .post('/api/commands')
+      .send({ instruction: 'do', selectedText: 'test' });
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('Hello World');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,5 +15,9 @@
     "ws": "^8.13.0",
     "y-websocket": "^1.5.0",
     "yjs": "^13.6.9"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -269,3 +269,5 @@ wss.on('connection', (conn, req) => {
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
+
+export { app, server };


### PR DESCRIPTION
## Summary
- add Jest and Supertest with test script for the backend
- cover document, plugin action, and AI endpoints with OpenAI mocks
- export server for testing and document test usage in README

## Testing
- `npm test` *(fails: Cannot find module 'backend/node_modules/jest/bin/jest.js' due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8be7b000832688adce35c83ef3c3